### PR TITLE
Configure Using Environment Variables

### DIFF
--- a/man/wemux.1.in
+++ b/man/wemux.1.in
@@ -89,7 +89,7 @@ Kill the wemux session and remove the /tmp/wemux\-wemux socket\.
 Kick an SSH user from the server and remove their wemux pair sessions\.
 .
 .SS "wemux config"
-Open \fB$(SYSCONFDIR)/wemux\.conf\fR in your $EDITOR\.
+Open \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf\fR by default) in your $EDITOR\.
 .
 .SS "wemux"
 When \fBwemux\fR is run without any arguments in host mode, it is just like running wemux start\. It will reattach to an existing wemux session if it exists, otherwise it will start a new session\.
@@ -118,7 +118,7 @@ If the client does not have an existing rogue session it will attach to the wemu
 If the client has already started a wemux rogue mode session, it will reattach to the session in rogue mode\.
 .
 .IP "\(bu" 4
-By setting \fBdefault_client_mode="rogue"\fR in \fBwemux\.conf\fR this can be changed to always join in pair mode, even if a pair session doesn\'t already exist\.
+By setting \fBdefault_client_mode="rogue"\fR in \fB$WEMUX_CONF\fR this can be changed to always join in pair mode, even if a pair session doesn\'t already exist\.
 .
 .IP "" 0
 .
@@ -181,7 +181,7 @@ bind t run\-shell \'wemux display_users\'
 Note that the tmux prefix should be pressed before t to activate the command\.
 .
 .P
-User listing can be disabled by setting \fBallow_user_list="false"\fR in \fBwemux\.conf\fR
+User listing can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR
 .
 .SS "Short\-form Commands"
 All commands have a short form\. s for start, a for attach, p for pair etc\. For a complete list, type \fBwemux help\fR (or \fBwemux h\fR)
@@ -193,7 +193,7 @@ wemux supports specifying the joining different wemux sessions via \fBwemux join
 wemux will remember the last session specified to in order to make reconnecting to the same session easy\. \fBwemux help\fR will output the currently specified session along with the wemux command list\.
 .
 .P
-Changing sessions can be enabled by setting \fBallow_session_change="true"\fR in \fB$(SYSCONFDIR)/wemux\.conf\fR
+Changing sessions can be enabled by setting \fBallow_session_change="true"\fR in \fB$WEMUX_CONF\fR
 .
 .SS "Joining Different wemux Sessions"
 To change the wemux session run \fBwemux join <session>\fR\. The name will be sanitized to contain no spaces or uppercase letters\.
@@ -260,7 +260,7 @@ Current wemux server: wemux
 In order to easily return to the default session you can run \fBwemux reset\fR
 .
 .SS "wemux reset"
-Joins the default wemux session: wemux (or value of default_session_name in wemux\.conf)
+Joins the default wemux session: wemux (or value of default_session_name in $WEMUX_CONF)
 .
 .IP "" 4
 .
@@ -297,15 +297,15 @@ Currently active wemux sessions:
 \fBwemux join\fR and \fBwemux stop\fR both accept either the name of a session or the number indicated next to the name in \fBwemux list\fR\.
 .
 .P
-Listing sessions can be disabled by setting \fBallow_session_list="false"\fR in \fB$(SYSCONFDIR)/wemux\.conf\fR
+Listing sessions can be disabled by setting \fBallow_session_list="false"\fR in \fB$WEMUX_CONF\fR
 .
 .SH "CONFIGURATION"
-There are a number of additional options that be configured in \fB$(SYSCONFDIR)/wemux\.conf\fR\. In most cases the only option that must be changed is the \fBhost_list\fR array\. To open your wemux configuration file, you can either open \fB$(SYSCONFDIR)/wemux\.conf\fR manually or run \fBwemux config\fR
+There are a number of additional options that be configured in \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf by default)\. In most cases the only option that must be changed is the \fBhost_list\fR array\. To open your wemux configuration file, you can either open \fB$WEMUX_CONF\fR manually or run \fBwemux config\fR
 .
-An example configuration file is available at \fB$(DOCDIR)/wemux.conf.example\fR.
+An example configuration file is available at \fB$DOCDIR/wemux.conf.example\fR.
 .
 .SS "Host Mode"
-To have an account act as host, ensure that you have added their username to the \fB$(SYSCONFDIR)/wemux\.conf\fR file\'s \fBhost_list\fR array\.
+To have an account act as host, ensure that you have added their username to the \fB$WEMUX_CONF\fR file\'s \fBhost_list\fR array\.
 .
 .IP "" 4
 .
@@ -330,7 +330,7 @@ When clients enter \'wemux\' with no arguments by default it will first attempt 
 This can be changed by setting \fBdefault_client_mode="rogue"\fR
 .
 .SS "Default Session Name"
-The default wemux session name will be used with \fBwemux reset\fR and when \fBallow_session_change\fR is not enabled in \fBwemux\.conf\fR\.
+The default wemux session name will be used with \fBwemux reset\fR and when \fBallow_session_change\fR is not enabled in \fB$WEMUX_CONF\fR\.
 .
 .P
 This can be changed by setting \fBdefault_session_name="customname"\fR
@@ -342,10 +342,10 @@ The ability to change sessions can be enabled by setting \fBallow_session_change
 Listing sessions can be disabled by setting \fBallow_session_list="false"\fR
 .
 .SS "Listing Users"
-Listing users can be disabled by setting \fBallow_user_list="false"\fR in \fBwemux\.conf\fR
+Listing users can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR
 .
 .SS "Kicking SSH Users"
-Kicking SSH users from the server can be disabled by setting \fBallow_kick_user="false"\fR in \fBwemux\.conf\fR
+Kicking SSH users from the server can be disabled by setting \fBallow_kick_user="false"\fR in \fB$WEMUX_CONF\fR
 .
 .SS "Announcements"
 When a user joins a session in either mirror or pair mode, a message is displayed to all currently attached users:

--- a/man/wemux.1.in
+++ b/man/wemux.1.in
@@ -89,7 +89,7 @@ Kill the wemux session and remove the /tmp/wemux\-wemux socket\.
 Kick an SSH user from the server and remove their wemux pair sessions\.
 .
 .SS "wemux config"
-Open \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf\fR by default) in your $EDITOR\.
+Open \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf\fR by default) in your \fB$EDITOR\fR\.
 .
 .SS "wemux"
 When \fBwemux\fR is run without any arguments in host mode, it is just like running wemux start\. It will reattach to an existing wemux session if it exists, otherwise it will start a new session\.
@@ -118,7 +118,7 @@ If the client does not have an existing rogue session it will attach to the wemu
 If the client has already started a wemux rogue mode session, it will reattach to the session in rogue mode\.
 .
 .IP "\(bu" 4
-By setting \fBdefault_client_mode="rogue"\fR in \fB$WEMUX_CONF\fR this can be changed to always join in pair mode, even if a pair session doesn\'t already exist\.
+By setting \fBdefault_client_mode="rogue"\fR in \fB$WEMUX_CONF\fR or by setting the environment variable \fBWEMUX_DEFAULT_CLIENT_MODE="rogue"\fR this can be changed to always join in pair mode, even if a pair session doesn\'t already exist\.
 .
 .IP "" 0
 .
@@ -181,7 +181,7 @@ bind t run\-shell \'wemux display_users\'
 Note that the tmux prefix should be pressed before t to activate the command\.
 .
 .P
-User listing can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR
+User listing can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR or by setting the environment variable \fBWEMUX_ALLOW_USER_LIST="false"\fR
 .
 .SS "Short\-form Commands"
 All commands have a short form\. s for start, a for attach, p for pair etc\. For a complete list, type \fBwemux help\fR (or \fBwemux h\fR)
@@ -193,7 +193,7 @@ wemux supports specifying the joining different wemux sessions via \fBwemux join
 wemux will remember the last session specified to in order to make reconnecting to the same session easy\. \fBwemux help\fR will output the currently specified session along with the wemux command list\.
 .
 .P
-Changing sessions can be enabled by setting \fBallow_session_change="true"\fR in \fB$WEMUX_CONF\fR
+Changing sessions can be enabled by setting \fBallow_session_change="true"\fR in \fB$WEMUX_CONF\fR or by setting the environment varialbe \fBWEMUX_ALLOW_SESSION_CHANGE="true"\fR
 .
 .SS "Joining Different wemux Sessions"
 To change the wemux session run \fBwemux join <session>\fR\. The name will be sanitized to contain no spaces or uppercase letters\.
@@ -260,7 +260,7 @@ Current wemux server: wemux
 In order to easily return to the default session you can run \fBwemux reset\fR
 .
 .SS "wemux reset"
-Joins the default wemux session: wemux (or value of default_session_name in $WEMUX_CONF)
+Joins the default wemux session: wemux (or value of default_session_name in \fB$WEMUX_CONF\fR or value of the environment variable \fBWEMUX_DEFAULT_SESSION_NAME\fR)
 .
 .IP "" 4
 .
@@ -297,15 +297,15 @@ Currently active wemux sessions:
 \fBwemux join\fR and \fBwemux stop\fR both accept either the name of a session or the number indicated next to the name in \fBwemux list\fR\.
 .
 .P
-Listing sessions can be disabled by setting \fBallow_session_list="false"\fR in \fB$WEMUX_CONF\fR
+Listing sessions can be disabled by setting \fBallow_session_list="false"\fR in \fB$WEMUX_CONF\fR or by setting the environment variable \fBWEMUX_ALLOW_SESSION_LIST="false"\fR
 .
 .SH "CONFIGURATION"
-There are a number of additional options that be configured in \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf by default)\. In most cases the only option that must be changed is the \fBhost_list\fR array\. To open your wemux configuration file, you can either open \fB$WEMUX_CONF\fR manually or run \fBwemux config\fR
+There are a number of additional options that be configured in \fB$WEMUX_CONF\fR (\fB$SYSCONFDIR/wemux\.conf\fR or \fB/usr/local/etc/wemux\.conf\fR by default)\. In most cases the only option that must be changed is the \fBhost_list\fR array\. To open your wemux configuration file, you can either open \fB$WEMUX_CONF\fR manually or run \fBwemux config\fR\. You can also set environment variables to control configuration, although these have lower precedence than the configuration file; the configuration file can be ignored by setting \fB$WEMUX_CONF\fR to the empty string, e.g. `\fBexport WEMUX_CONF=\fR`\.
 .
 An example configuration file is available at \fB$DOCDIR/wemux.conf.example\fR.
 .
 .SS "Host Mode"
-To have an account act as host, ensure that you have added their username to the \fB$WEMUX_CONF\fR file\'s \fBhost_list\fR array\.
+To have an account act as host, ensure that you have added their username to the \fB$WEMUX_CONF\fR file\'s \fBhost_list\fR array or to the environment variable \fBWEMUX_HOST_LIST\fR, a space-delimited list of user names (whitespace can be protected by quotes)\. If \fBhost_list\fR is set in \fB$WEMUX_CONF\fR, \fBWEMUX_HOST_LIST\fR is ignored\.
 .
 .IP "" 4
 .
@@ -313,39 +313,41 @@ To have an account act as host, ensure that you have added their username to the
 
 host_list=(zolrath hostusername brocksamson)
 .
+WEMUX_HOST_LIST="zolrath hostusername brocksamson"
+.
 .fi
 .
 .IP "" 0
 .
 .SS "Pair Mode"
-Pair mode can be disabled, only allowing clients to attach to the session in mirror mode by setting \fBallow_pair_mode="false"\fR
+Pair mode can be disabled, only allowing clients to attach to the session in mirror mode by setting \fBallow_pair_mode="false"\fR or by setting the environment varialbe \fBWEMUX_ALLOW_PAIR_MODE="false"\fR
 .
 .SS "Rogue Mode"
-Rogue mode can be disabled, only allowing clients to attach to the server in mirror or pair mode by setting \fBallow_rogue_mode="false"\fR
+Rogue mode can be disabled, only allowing clients to attach to the server in mirror or pair mode by setting \fBallow_rogue_mode="false"\fR or by setting the environment varialbe \fBWEMUX_ALLOW_ROGUE_MODE="false"\fR
 .
 .SS "Default Client Mode"
-When clients enter \'wemux\' with no arguments by default it will first attempt to join an existing rogue mode session\. If there is no rogue session it will start in pair mode\. By setting default_client_mode to "rogue", \'wemux\' with no arguments will always join a rogue mode session, even if it has to create it\.
+When clients enter \'wemux\' with no arguments by default it will first attempt to join an existing rogue mode session\. If there is no rogue session it will start in pair mode\. By setting \fBdefault_client_mode\fR or the environment variable \fBWEMUX_DEFAULT_CLIENT_MODE\fR to "rogue", \'wemux\' with no arguments will always join a rogue mode session, even if it has to create it\.
 .
 .P
-This can be changed by setting \fBdefault_client_mode="rogue"\fR
+This can be changed by setting \fBdefault_client_mode="rogue"\fR or by setting the environment variable \fBWEMUX_DEFAULT_CLIENT_MODE="rogue"\fR
 .
 .SS "Default Session Name"
 The default wemux session name will be used with \fBwemux reset\fR and when \fBallow_session_change\fR is not enabled in \fB$WEMUX_CONF\fR\.
 .
 .P
-This can be changed by setting \fBdefault_session_name="customname"\fR
+This can be changed by setting \fBdefault_session_name="customname"\fR or by setting the environment variable \fBWEMUX_DEFAULT_SESSION_NAME="customname"\fR
 .
 .SS "Changing Sessions"
-The ability to change sessions can be enabled by setting \fBallow_session_change="true"\fR
+The ability to change sessions can be enabled by setting \fBallow_session_change="true"\fR or by setting the environment variable \fBWEMUX_ALLOW_SESSION_CHANGE="true"\fR
 .
 .SS "Listing Sessions"
-Listing sessions can be disabled by setting \fBallow_session_list="false"\fR
+Listing sessions can be disabled by setting \fBallow_session_list="false"\fR or by setting the environment variable \fBWEMUX_ALLOW_SESSION_LIST="false"\fR
 .
 .SS "Listing Users"
-Listing users can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR
+Listing users can be disabled by setting \fBallow_user_list="false"\fR in \fB$WEMUX_CONF\fR or by setting the environment varialbe \fBWEMUX_ALLOW_USER_LIST="false"\fR
 .
 .SS "Kicking SSH Users"
-Kicking SSH users from the server can be disabled by setting \fBallow_kick_user="false"\fR in \fB$WEMUX_CONF\fR
+Kicking SSH users from the server can be disabled by setting \fBallow_kick_user="false"\fR in \fB$WEMUX_CONF\fR or by setting the environment varialble \fBWEMUX_ALLOW_KICK_USER="false"\fR
 .
 .SS "Announcements"
 When a user joins a session in either mirror or pair mode, a message is displayed to all currently attached users:
@@ -362,7 +364,7 @@ csagan has detached\.
 .IP "" 0
 .
 .P
-This can be disabled by setting \fBannounce_attach="false"\fR
+This can be disabled by setting \fBannounce_attach="false"\fR or by setting the environment variable \fBWEMUX_ANNOUNCE_ATTACH="false"\fB
 .
 .P
 In addition, when a user switches from one session to another via the \fBwemux join <sessionname>\fR command, their movement is displayed similarly to the attach messages\.
@@ -394,7 +396,7 @@ csagan has joined this session\.
 .IP "" 0
 .
 .P
-This can be disabled by setting \fBannounce_session_change="false"\fR
+This can be disabled by setting \fBannounce_session_change="false"\fR or by setting the environment variable \fBWEMUX_ANNOUNCE_SESSION_CHANGE="false"\fR
 .
 .SS "Automatic SSH Client Modes"
 To make an SSHed user start in a wemux mode automatically, add one of the following lines to the users \fB\.bash_profile\fR or \fB\.zshrc\fR

--- a/wemux.in
+++ b/wemux.in
@@ -47,20 +47,20 @@ version="3.2.0"
 
 # Setup and Configuration Files.
 # Default settings, modify them in the $WEMUX_CONF file:
-host_list=(change_this_in_wemux_conf)
-host_groups=()
-socket_prefix="/tmp/wemux"
-options="-u"
-allow_pair_mode="true"
-allow_rogue_mode="true"
-default_client_mode="mirror"
-allow_kick_user="true"
-allow_server_change="false"
-default_server_name="wemux"
-allow_server_list="true"
-allow_user_list="true"
-announce_attach="true"
-announce_server_change="true"
+IFS=$'\n' host_list=($(xargs -n 1 <<< "${WEMUX_HOST_LIST:-change_this_in_wemux_conf}"))
+IFS=$'\n' host_groups=($(xargs -n 1 <<< "$WEMUX_HOST_GROUPS"))
+socket_prefix="${WEMUX_SOCKET_PREFIX:-/tmp/wemux}"
+options="${WEMUX_OPTIONS:--u}"
+allow_pair_mode="${WEMUX_ALLOW_PAIR_MODE:-true}"
+allow_rogue_mode="${WEMUX_ALLOW_ROGUE_MODE:-true}"
+default_client_mode="${WEMUX_DEFAULT_CLIENT_MODE:-mirror}"
+allow_kick_user="${WEMUX_ALLOW_KICK_USER:-true}"
+allow_server_change="${WEMUX_ALLOW_SERVER_CHANGE:-false}"
+default_server_name="${WEMUX_DEFAULT_SERVER_NAME:-wemux}"
+allow_server_list="${WEMUX_ALLOW_SERVER_LIST:-true}"
+allow_user_list="${WEMUX_ALLOW_USER_LIST:-true}"
+announce_attach="${WEMUX_ANNOUNCE_ATTACH:-true}"
+announce_server_change="${WEMUX_ANNOUNCE_SERVER_CHANGE:-true}"
 
 # Prevent users from changing their $USER env variable to become host.
 username=`whoami`

--- a/wemux.in
+++ b/wemux.in
@@ -9,8 +9,8 @@
 # in another window (separate cursors) in the hosts tmux session.
 #
 # To set a user as host add their username to the host_list in the configuration
-# file located at $(SYSCONFDIR)/wemux.conf
-# Other configuations options are also located in $(SYSCONFDIR)/wemux.conf
+# file located at $WEMUX_CONF (default $SYSCONFDIR/wemux.conf)
+# Other configuations options are also located in $WEMUX_CONF
 #
 # For environments with multiple hosts running their own independent servers
 # on the same machine wemux can join different servers with the wemux join
@@ -34,7 +34,7 @@
 # wemux users : List the currently attached wemux users.
 # wemux help  : Display the help screen.
 #
-# To enable multi-host commands, set allow_server_change="true" in wemux.conf
+# To enable multi-host commands, set allow_server_change="true" in $WEMUX_CONF
 # WEMUX SESSION COMMANDS: can be run by either host or client.
 # wemux join  : Join wemux server with supplied name.
 # wemux reset : Join default wemux server: wemux
@@ -46,7 +46,7 @@
 version="3.2.0"
 
 # Setup and Configuration Files.
-# Default settings, modify them in the $(SYSCONFDIR)/wemux.conf file:
+# Default settings, modify them in the $WEMUX_CONF file:
 host_list=(change_this_in_wemux_conf)
 host_groups=()
 socket_prefix="/tmp/wemux"
@@ -67,8 +67,11 @@ username=`whoami`
 # Set $EDITOR default to vi if not configured on host machine.
 editor=${EDITOR:="vi"}
 
-# Load configuration options from $(SYSCONFDIR)/wemux.conf
-[ -f $(SYSCONFDIR)/wemux.conf ] && . $(SYSCONFDIR)/wemux.conf
+# Load configuration options from $WEMUX_CONF
+# default location is $SYSCONFDIR/wemux.conf, or /usr/local/etc/wemux.conf if
+# $SYSCONFDIR isn't set
+: "${WEMUX_CONF:=${SYSCONFDIR:-/usr/local/etc}/wemux.conf}"
+[ -f "$WEMUX_CONF" ] && . "$WEMUX_CONF"
 
 # Sanitize server name, replace spaces and underscores with dashes.
 # Remove all non alpha-numeric characters, convert to lowercase.
@@ -83,7 +86,7 @@ sanitize_server_name() {
 
 # Load the server name of last wemux server. If empty, set to 'wemux'.
 # Ensure server name is 'wemux' if allow_server_change is disabled.
-# If default_server_name is set in wemux.conf it will be used instead of 'wemux'
+# If default_server_name is set in $WEMUX_CONF it will be used instead of 'wemux'
 load_server_name() {
   if [ "$allow_server_change" == "true" ]; then
     if [ -f ~/.wemux_last_server ]; then
@@ -318,7 +321,7 @@ kill_server_successful() {
 }
 
 # Announce when user attaches/detaches from server.
-# Can be disabled by changing announce_attach to false in $(SYSCONFDIR)/wemux.conf
+# Can be disabled by changing announce_attach to false in $WEMUX_CONF
 # The first argument specifies the mode the user is attaching in for the message
 # All additional arguments get wrapped in the attach/detach messages.
 announce_connection() {
@@ -333,7 +336,7 @@ announce_connection() {
 }
 
 # Announces when a user joins/changes their server.
-# Can be disabled by changing announce_server_change to false in $(SYSCONFDIR)/wemux.conf
+# Can be disabled by changing announce_server_change to false in $WEMUX_CONF
 # Change server name for server, or display server name if no argument is given.
 change_server() {
   if [ "$allow_server_change" == "true" ]; then
@@ -375,7 +378,7 @@ display_version() {
   echo "To check for a newer version visit: http://www.github.com/zolrath/wemux"
 }
 
-# Host mode, used when user is listed in the host_list array in $(SYSCONFDIR)/wemux.conf
+# Host mode, used when user is listed in the host_list array in $WEMUX_CONF
 host_mode() {
   # Start the server if it doesn't exist, otherwise reattach.
   start_server() {
@@ -516,7 +519,7 @@ host_mode() {
       status_users)       status_users;;
       display_users)      display_users;;
       version|v)          display_version;;
-      conf*|c)            $editor $(SYSCONFDIR)/wemux.conf;;
+      conf*|c)            $editor "$WEMUX_CONF";;
       *)                  if ! $wemux "$@"; then
                             echo "To see a list of wemux commands enter 'wemux help'"
                             exit 127
@@ -525,7 +528,7 @@ host_mode() {
   fi
 }
 
-# Client Mode, used when user is NOT listed in the host_list in $(SYSCONFDIR)/wemux.conf
+# Client Mode, used when user is NOT listed in the host_list in $WEMUX_CONF
 client_mode() {
   # Mirror mode, allows the user to view wemux server in read only mode.
   mirror_mode() {
@@ -601,10 +604,10 @@ client_mode() {
   }
 
   smart_reattach() {
-    # If default_client_mode has been set to "rogue" in wemux.conf:
+    # If default_client_mode has been set to "rogue" in $WEMUX_CONF:
     if [ "$default_client_mode" == "rogue" ] && [ "$allow_rogue_mode" == "true" ]; then
       announce_connection "rogue" rogue_mode
-    # If default_client_mode has been set to "pair" in wemux.conf:
+    # If default_client_mode has been set to "pair" in $WEMUX_CONF:
     elif [ "$default_client_mode" == "pair" ] && [ "$allow_pair_mode" == "true" ]; then
       announce_connection "pair" pair_mode
     elif has_rogue_session && [ "$allow_rogue_mode" == "true" ]; then


### PR DESCRIPTION
This patch enables users to configure `wemux` with environment variables rather than relying on a central configuration file. This is intended to help those on many-user systems (e.g. a supercomputer) to configure and use `wemux` as they see fit. If no `WEMUX_*` environment variables are set, `wemux` will behave identically.